### PR TITLE
Fixed NPC conversation conflicts

### DIFF
--- a/Assets/Fungus/Thirdparty/FungusLua/Scripts/Components/LuaScript.cs
+++ b/Assets/Fungus/Thirdparty/FungusLua/Scripts/Components/LuaScript.cs
@@ -124,7 +124,7 @@ namespace Fungus
         /// Execute the Lua script.
         /// This is the function to call if you want to trigger execution from an external script.
         /// </summary>
-        public virtual void OnExecute()
+        public virtual void OnExecute(System.Action<DynValue> onComplete = null)
         {
             // Make sure the script and Lua environment are initialised before executing
             InitLuaScript();
@@ -135,7 +135,7 @@ namespace Fungus
             }
             else
             {
-                luaEnvironment.RunLuaFunction(luaFunction, runAsCoroutine);
+                luaEnvironment.RunLuaFunction(luaFunction, runAsCoroutine, onComplete);
             }
         }
 

--- a/Assets/IndieGame/Components/NPC.cs
+++ b/Assets/IndieGame/Components/NPC.cs
@@ -10,6 +10,8 @@ public class NPC : MonoBehaviour
 
     protected LuaScript npcScript;
 
+    protected bool busy = false;
+
 	void Start () {
         LoadNPCScript();
 	}
@@ -40,7 +42,14 @@ public class NPC : MonoBehaviour
     {
         if (npcScript != null)
         {
-            npcScript.OnExecute();
+            if (busy)
+            {
+                return;
+            }
+
+            busy = true;
+
+            npcScript.OnExecute(delegate { busy = false; });
         }
     }
 


### PR DESCRIPTION
Fixed when trying to run a new conversation on an NPC when another was
already active by adding a busy attribute to the NPC.